### PR TITLE
Release tag regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^\d+\.\d+(\.\d+)?$/
+              only: /^v\d+\.\d+(\.\d+)?$/
       - release:
           requires:
             - build
@@ -54,4 +54,4 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+\.\d+(\.\d+)?$/
+              only: /^v\d+\.\d+(\.\d+)?$/


### PR DESCRIPTION
Changed release tag regex to use the 'v' letter. Ex: v1.2[.3]