### PR TITLE
Makefile GOPATH Evalueation fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
-tyr.log
+cloud-security-audit.log
 debug.test
-tyr
+cloud-security-audit

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ test: get-deps create-mocks
 
 
 create-mocks: get-mockgen
-	GOPATH=`go env GOPATH` ; $(GOPATH)/bin/mockgen -source=./csasession/clientfactory/ec2client.go -destination=./csasession/clientfactory/mocks/ec2client_mock.go -package=mocks EC2Client
-	GOPATH=`go env GOPATH` ; $(GOPATH)/bin/mockgen -source=./csasession/clientfactory/kmsclient.go -destination=./csasession/clientfactory/mocks/kmsclient_mock.go -package=mocks KmsClient
-	GOPATH=`go env GOPATH` ; $(GOPATH)/bin/mockgen -source=./csasession/clientfactory/s3client.go -destination=./csasession/clientfactory/mocks/s3client_mock.go -package=mocks S3Client
+	`go env GOPATH`/bin/mockgen -source=./csasession/clientfactory/ec2client.go -destination=./csasession/clientfactory/mocks/ec2client_mock.go -package=mocks EC2Client
+	`go env GOPATH`/bin/mockgen -source=./csasession/clientfactory/kmsclient.go -destination=./csasession/clientfactory/mocks/kmsclient_mock.go -package=mocks KmsClient
+	`go env GOPATH`/bin/mockgen -source=./csasession/clientfactory/s3client.go -destination=./csasession/clientfactory/mocks/s3client_mock.go -package=mocks S3Client
 
 
 get-mockgen:


### PR DESCRIPTION
Fixed creation of mocks using GOPATH evalueation and updated .gitignore

This closes #50 